### PR TITLE
fix: prevent duplicate Indeks when adding KLE tasks

### DIFF
--- a/IntegrationLayer/Source/stubs/helpers/OrganisationEnhedStubHelper.cs
+++ b/IntegrationLayer/Source/stubs/helpers/OrganisationEnhedStubHelper.cs
@@ -210,7 +210,7 @@ namespace Organisation.IntegrationLayer
                 int idx = 0;
                 OpgaverFlerRelationType[] opgaverTypes = new OpgaverFlerRelationType[newSize];
 
-                int currentMaxIdx = 1;
+                int currentMaxIdx = 0;
                 // copy existing (but set a stop-date on those flagged for removal)
                 if (registration.RelationListe?.Opgaver != null)
                 {
@@ -247,7 +247,7 @@ namespace Organisation.IntegrationLayer
                     opgaveType.ReferenceID = tilknytteFunktionId;
                     opgaveType.Virkning = virkning;
 
-                    opgaveType.Indeks = (currentMaxIdx++).ToString();
+                    opgaveType.Indeks = (++currentMaxIdx).ToString();
 
                     // Ansvarlig
                     opgaveType.Rolle = new UuidLabelInputType();


### PR DESCRIPTION
UpdateOpgaver initialised currentMaxIdx to 1 and assigned new Opgave indices with a post-increment, so the first new task reused the existing maximum Indeks instead of going above it. FK Organisation rejects a Ret containing two relations with the same (Rolle, Type, Indeks) with StatusKode 40, which silently dropped the new KLE.

Initialise currentMaxIdx to 0 and use a pre-increment so new tasks are always assigned an Indeks strictly greater than the current maximum.